### PR TITLE
Remove _ga query param when linking from .org to .org

### DIFF
--- a/js/guides-4.10.js
+++ b/js/guides-4.10.js
@@ -256,7 +256,7 @@ document.addEventListener("DOMContentLoaded", function () {
         "allowLinker": true
     });
     window.ga("all.require", "linker");
-    window.ga("all.linker:autoLink", ["gradle.com", "gradle.org"], false, true);
+    window.ga("all.linker:autoLink", ["gradle.com"], false, true);
     window.ga("create", "UA-4207603-11", "auto", "guides");
     window.ga("all.set", "transport", "beacon");
     window.ga("guides.set", "transport", "beacon");

--- a/js/guides-4.7.js
+++ b/js/guides-4.7.js
@@ -221,7 +221,7 @@ document.addEventListener("DOMContentLoaded", function() {
         "allowLinker": true
     });
     window.ga("all.require", "linker");
-    window.ga("all.linker:autoLink", ["gradle.com", "gradle.org"], false, true);
+    window.ga("all.linker:autoLink", ["gradle.com"], false, true);
     window.ga("create", "UA-4207603-11", "auto", "guides");
     window.ga("all.set", "transport", "beacon");
     window.ga("guides.set", "transport", "beacon");

--- a/js/guides-4.8.js
+++ b/js/guides-4.8.js
@@ -248,7 +248,7 @@ document.addEventListener("DOMContentLoaded", function () {
         "allowLinker": true
     });
     window.ga("all.require", "linker");
-    window.ga("all.linker:autoLink", ["gradle.com", "gradle.org"], false, true);
+    window.ga("all.linker:autoLink", ["gradle.com"], false, true);
     window.ga("create", "UA-4207603-11", "auto", "guides");
     window.ga("all.set", "transport", "beacon");
     window.ga("guides.set", "transport", "beacon");

--- a/js/guides.js
+++ b/js/guides.js
@@ -256,7 +256,7 @@ document.addEventListener("DOMContentLoaded", function () {
         "allowLinker": true
     });
     window.ga("all.require", "linker");
-    window.ga("all.linker:autoLink", ["gradle.com", "gradle.org"], false, true);
+    window.ga("all.linker:autoLink", ["gradle.com"], false, true);
     window.ga("create", "UA-4207603-11", "auto", "guides");
     window.ga("all.set", "transport", "beacon");
     window.ga("guides.set", "transport", "beacon");


### PR DESCRIPTION
- Remove _ga query param when linking from .org to .org