### PR TITLE
Simplify example in Using the worker API / Create a custom task class

### DIFF
--- a/subprojects/using-the-worker-api/samples/code/custom-task/buildSrc/src/main/java/CreateMD5.java
+++ b/subprojects/using-the-worker-api/samples/code/custom-task/buildSrc/src/main/java/CreateMD5.java
@@ -1,10 +1,8 @@
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
@@ -17,23 +15,16 @@ import java.io.InputStream;
 
 public class CreateMD5 extends SourceTask { // <1>
     private final DirectoryProperty destinationDirectory; // <2>
-    private final ConfigurableFileCollection codecClasspath;
 
     @Inject
     public CreateMD5() {
         super();
         this.destinationDirectory = getProject().getObjects().directoryProperty();
-        this.codecClasspath = getProject().getObjects().fileCollection();
     }
 
     @OutputDirectory
     public DirectoryProperty getDestinationDirectory() {
         return destinationDirectory;
-    }
-
-    @InputFiles
-    public ConfigurableFileCollection getCodecClasspath() {
-        return codecClasspath;
     }
 
     @TaskAction


### PR DESCRIPTION
The attribute `codecClasspath` of the `CreateMD5` class isn't used and has been removed
to improve the comprehensibility of the example.
