### PR TITLE
Replaced deprecated property `archiveName` of zip task in `basic-demo`.

### DIFF
--- a/subprojects/creating-new-gradle-builds/samples/code/zip.gradle
+++ b/subprojects/creating-new-gradle-builds/samples/code/zip.gradle
@@ -9,6 +9,6 @@ version = "1.0"
 // tag::zip[]
 task zip(type: Zip, group: "Archive", description: "Archives sources in a zip file") {
     from "src"
-    setArchiveName "basic-demo-1.0.zip"
+    setArchiveFileName "basic-demo-1.0.zip"
 }
 // end::zip[]

--- a/subprojects/creating-new-gradle-builds/samples/code/zip.gradle.kts
+++ b/subprojects/creating-new-gradle-builds/samples/code/zip.gradle.kts
@@ -12,6 +12,6 @@ tasks.create<Zip>("zip") {
     group = "Archive"
 
     from("src")
-    setArchiveName("basic-demo-1.0.zip")
+    archiveFileName.set("basic-demo-1.0.zip")
 }
 // end::zip[]


### PR DESCRIPTION
After executing task _zip_ from this location:
https://guides.gradle.org/creating-new-gradle-builds/

there was the warning of deprecation:

```
basic-demo ./gradlew zip

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0.1/userguide/command_line_interface.html#sec:command_line_warnings
```

and more detailed:
```
basic-demo ./gradlew zip --warning-mode all

> Configure project :
The archiveName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveFileName property instead.
``` 