### PR TITLE
Do not include duplicate directories in the generated sample zips

### DIFF
--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -121,14 +121,14 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
         makeSingleProject()
         writeSampleUnderTest()
         buildFile << """
-            ${sampleUnderTestDsl}.dsls = [] 
+            ${sampleUnderTestDsl}.dsls = []
         """
 
         when:
         buildAndFail('assembleDemoSample')
 
         then:
-        result.output.contains("Samples must have at least one DSL, sample 'demo' has none.")
+        result.output.contains("Samples must define at least one DSL, sample 'demo' has none.")
     }
 
     def "detects DSL based on content available"() {
@@ -160,7 +160,7 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
 
         when:
         buildFile << """
-            ${sampleUnderTestDsl}.description = "Some description"     
+            ${sampleUnderTestDsl}.description = "Some description"
         """
         and:
         build('assemble')
@@ -204,18 +204,24 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
     def "can use template for source of common content"() {
         makeSingleProject()
         writeSampleUnderTest()
-        file("src/docs/samples/templates/template-dir/a.txt") << "aaaa"
-        file("src/docs/samples/templates/template-dir/subdir/b.txt") << "bbbb"
+        file("src/docs/samples/templates/template-one/a.txt") << "aaaa"
+        file("src/docs/samples/templates/template-one/subdir/b.txt") << "bbbb"
+        file("src/docs/samples/templates/template-two/c.txt") << "cccc"
+        file("src/docs/samples/templates/template-two/subdir/d.txt") << "dddd"
+        file("src/docs/samples/demo/groovy/subdir/e.txt") << "eeee"
+        file("src/docs/samples/demo/kotlin/subdir/e.txt") << "eeee"
         buildFile << """
             documentation {
                 samples {
                     templates {
-                        templateDir
+                        templateOne
+                        templateTwo
                     }
                     publishedSamples {
                         demo {
                             common {
-                                from(templates.templateDir)
+                                from(templates.templateOne)
+                                from(templates.templateTwo)
                             }
                         }
                     }
@@ -229,10 +235,14 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
         def demoGroovyZip = file("build/sample-zips/sample_demo-groovy-dsl.zip").asZip()
         demoGroovyZip.assertDescendantHasContent("a.txt", equalTo("aaaa"))
         demoGroovyZip.assertDescendantHasContent("subdir/b.txt", equalTo("bbbb"))
+        demoGroovyZip.assertDescendantHasContent("c.txt", equalTo("cccc"))
+        demoGroovyZip.assertDescendantHasContent("subdir/d.txt", equalTo("dddd"))
 
         def demoKotlinZip = file("build/sample-zips/sample_demo-groovy-dsl.zip").asZip()
         demoKotlinZip.assertDescendantHasContent("a.txt", equalTo("aaaa"))
         demoKotlinZip.assertDescendantHasContent("subdir/b.txt", equalTo("bbbb"))
+        demoKotlinZip.assertDescendantHasContent("c.txt", equalTo("cccc"))
+        demoKotlinZip.assertDescendantHasContent("subdir/d.txt", equalTo("dddd"))
     }
 
     def "can execute the sample from the zip"() {
@@ -249,7 +259,7 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
 
     def "sorts samples by category and display name"() {
         makeSingleProject()
-        buildFile << """ 
+        buildFile << """
             ${createSample('zzz')} {
                 category = "Special"
             }

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -399,7 +399,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             // TODO: This should only be enforced if we are trying to build the given sample
             Set<Dsl> dsls = sample.getDsls().get();
             if (dsls.isEmpty()) {
-                throw new GradleException("Samples must have at least one DSL, sample '" + sample.getName() + "' has none.");
+                throw new GradleException("Samples must define at least one DSL, sample '" + sample.getName() + "' has none.");
             }
             for (Dsl dsl : dsls) {
                 SampleArchiveBinary binary = registerSampleBinaryForDsl(extension, sample, dsl, objects, wrapperFiles, contentBinary);

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/ZipSample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/ZipSample.java
@@ -22,6 +22,8 @@ import org.apache.tools.zip.ZipOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Zips a sample to the given location.
@@ -33,6 +35,7 @@ public abstract class ZipSample extends DefaultTask {
     protected FileTree getSourceAsTree() {
         return getSource().getAsFileTree();
     }
+
     @InputFiles
     @SkipWhenEmpty
     protected FileTree getMainSourceAsTree() {
@@ -62,10 +65,15 @@ public abstract class ZipSample extends DefaultTask {
         try (FileOutputStream fileStream = new FileOutputStream(zipFile);
              ZipOutputStream zipStream = new ZipOutputStream(fileStream)) {
             zipStream.setMethod(ZipOutputStream.DEFLATED);
+            Set<String> dirs = new HashSet<>();
             getFilteredSourceTree().visit(new FileVisitor() {
                 @Override
                 public void visitDir(FileVisitDetails dirDetails) {
                     try {
+                        String dirPath = dirDetails.getRelativePath().getPathString();
+                        if (!dirs.add(dirPath)) {
+                            return;
+                        }
                         ZipEntry entry = new ZipEntry(dirDetails.getRelativePath().getPathString() + "/");
                         entry.setUnixMode(UnixStat.DIR_FLAG | dirDetails.getMode());
                         zipStream.putNextEntry(entry);


### PR DESCRIPTION
Fix the sample Zip generation to ignore duplicate directories, which can happen when the various templates for a sample happen to include the same directories but different files.

This PR does not attempt to fix the problem of duplicate files.