### PR TITLE
Let clients configure the location of the readme

### DIFF
--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -1,5 +1,6 @@
 package org.gradle.docs.samples
 
+import org.gradle.docs.TestFile
 import spock.lang.Ignore
 import spock.lang.Unroll
 
@@ -94,6 +95,25 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
         buildAndFail("assembleDemoSample")
         then:
         result.task(":generateDemoPage").outcome == FAILED
+    }
+
+    def "can configure readme location"() {
+        makeSingleProject()
+        buildFile << """
+            ${sampleUnderTestDsl} {
+                readme = file('src/docs/samples/demo/CUSTOM_README.adoc')
+            }
+        """
+
+        TestFile directory = file('src/docs/samples/demo')
+        writeReadmeTo(directory, 'CUSTOM_README.adoc')
+        writeGroovyDslSampleTo(directory.file('groovy'))
+
+        when:
+        // If the readme doesn't exist for the sample, we fail to generate the sample page
+        ExecutionResult result = build("assembleDemoSample")
+        then:
+        result.task(":generateDemoPage").outcome == SUCCESS
     }
 
     // TODO: Generalize test

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -101,7 +101,7 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
         makeSingleProject()
         buildFile << """
             ${sampleUnderTestDsl} {
-                readme = file('src/docs/samples/demo/CUSTOM_README.adoc')
+                readmeFile = file('src/docs/samples/demo/CUSTOM_README.adoc')
             }
         """
 

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesTrait.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesTrait.groovy
@@ -33,8 +33,8 @@ trait SamplesTrait {
         return "documentation.samples.publishedSamples.${name}"
     }
 
-    static void writeReadmeTo(TestFile directory) {
-        directory.file('README.adoc') << '''
+    static void writeReadmeTo(TestFile directory, String file = 'README.adoc') {
+        directory.file(file) << '''
             |= Demo Sample
             |
             |Some doc

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
@@ -22,7 +22,7 @@ public interface Sample extends Named, SampleSummary {
      *
      * @return Property for configuring the readme file for the sample in Asciidoctor format.
      */
-    RegularFileProperty getReadme();
+    RegularFileProperty getReadmeFile();
 
     /**
      * @return Sample content that is shared by all DSLs.

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
@@ -4,6 +4,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 
 /**
  * Represent a sample to be documented. Each sample must contain at least a Groovy or Kotlin DSL sample.
@@ -17,9 +18,16 @@ public interface Sample extends Named, SampleSummary {
     DirectoryProperty getSampleDirectory();
 
     /**
+     * By Convention, this is README.adoc within the sample directory.
+     *
+     * @return Property for configuring the readme file for the sample in Asciidoctor format.
+     */
+    RegularFileProperty getReadme();
+
+    /**
      * @return Sample content that is shared by all DSLs.
      *
-     * By convention, this is the wrapper files, README and LICENSE.
+     * By convention, this is the wrapper files and LICENSE.
      */
     ConfigurableFileCollection getCommonContent();
 

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleArchiveBinary.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleArchiveBinary.java
@@ -1,6 +1,5 @@
 package org.gradle.docs.samples.internal;
 
-import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -173,7 +173,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
         extension.getDistribution().getTestedInstalledSamples().from(extension.getTestedInstallRoot());
         extension.getDistribution().getTestedInstalledSamples().builtBy(extension.getDistribution().getInstalledSamples().builtBy((Callable<List<DirectoryProperty>>) () -> extension.getBinaries().withType(SampleExemplarBinary.class).stream().map(SampleExemplarBinary::getTestedInstallDirectory).collect(Collectors.toList())));
 
-        // Tempates
+        // Templates
         // TODO: The following is only in samples
         extension.getTemplatesRoot().convention(layout.getProjectDirectory().dir("src/docs/samples/templates"));
 

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -198,6 +198,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
     private void applyConventionsForSamples(SamplesInternal extension, SampleInternal sample) {
         String name = sample.getName();
         sample.getSampleDirectory().convention(extension.getSamplesRoot().dir(toKebabCase(name)));
+        sample.getReadme().convention(sample.getSampleDirectory().file("README.adoc"));
         sample.getDisplayName().convention(toTitleCase(name));
         sample.getDescription().convention("");
         sample.getCategory().convention("Uncategorized");
@@ -392,7 +393,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             contentBinary.getResourceSpec().convention(project.copySpec(spec -> spec.from(extension.getDistribution().getZippedSamples(), sub -> sub.into("zips"))));
             contentBinary.getSourcePattern().convention(contentBinary.getBaseName().map(baseName -> baseName + ".adoc"));
             contentBinary.getSampleInstallDirectory().convention(sample.getInstallDirectory());
-            contentBinary.getSourcePageFile().convention(sample.getSampleDirectory().file("README.adoc"));
+            contentBinary.getSourcePageFile().convention(sample.getReadme());
             contentBinary.getGradleVersion().convention(project.getGradle().getGradleVersion());
 
             // TODO: To make this lazy without afterEvaluate/eagerness, we need to be able to tell the tasks container that the samples container should be consulted

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -198,7 +198,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
     private void applyConventionsForSamples(SamplesInternal extension, SampleInternal sample) {
         String name = sample.getName();
         sample.getSampleDirectory().convention(extension.getSamplesRoot().dir(toKebabCase(name)));
-        sample.getReadme().convention(sample.getSampleDirectory().file("README.adoc"));
+        sample.getReadmeFile().convention(sample.getSampleDirectory().file("README.adoc"));
         sample.getDisplayName().convention(toTitleCase(name));
         sample.getDescription().convention("");
         sample.getCategory().convention("Uncategorized");
@@ -393,7 +393,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             contentBinary.getResourceSpec().convention(project.copySpec(spec -> spec.from(extension.getDistribution().getZippedSamples(), sub -> sub.into("zips"))));
             contentBinary.getSourcePattern().convention(contentBinary.getBaseName().map(baseName -> baseName + ".adoc"));
             contentBinary.getSampleInstallDirectory().convention(sample.getInstallDirectory());
-            contentBinary.getSourcePageFile().convention(sample.getReadme());
+            contentBinary.getSourcePageFile().convention(sample.getReadmeFile());
             contentBinary.getGradleVersion().convention(project.getGradle().getGradleVersion());
 
             // TODO: To make this lazy without afterEvaluate/eagerness, we need to be able to tell the tasks container that the samples container should be consulted


### PR DESCRIPTION
Prior to this PR, the samples plugin assumed that each sample declare its documentation in the `README.adoc` within the sample directory. This blocks migrating the snippets to samples as we don't want to commit an auto-generated documentation file to each snippet.

With this change, clients can declare where the readme file is located:
```
samples {
  publishedSamples {
    mySample {
      readme = file('path/to/readme')
    }
  }
}
```
The default location is as before.