### PR TITLE
Remove user guide references from archived samples

### DIFF
--- a/subprojects/gradle-guides-plugin/build.gradle
+++ b/subprojects/gradle-guides-plugin/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 
     implementation 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
     implementation 'org.apache.ant:ant:1.9.13'
+    implementation 'com.google.guava:guava:29.0-jre'
 
     // For exemplar asciidoctor tests
     compileOnly("org.gradle:gradle-tooling-api:6.0.1")

--- a/subprojects/gradle-guides-plugin/build.gradle
+++ b/subprojects/gradle-guides-plugin/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 
     implementation 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2'
     implementation 'org.apache.ant:ant:1.9.13'
-    implementation 'com.google.guava:guava:29.0-jre'
 
     // For exemplar asciidoctor tests
     compileOnly("org.gradle:gradle-tooling-api:6.0.1")

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -311,14 +311,35 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
             |""".stripMargin()
     }
 
+    def "documentation references removed from source code in zip"() {
+        makeSingleProject()
+        writeSampleUnderTest()
+
+        when:
+        build('assembleDemoSample')
+
+        then:
+        assertZipEntryDoesNotContainDocRef(groovyDslZipFile, "build.gradle")
+        assertZipEntryDoesNotContainDocRef(kotlinDslZipFile, "build.gradle.kts")
+    }
+
     private void assertCanRunHelpTask(File zipFile) {
-        def workingDirectory = new File(temporaryFolder.root, zipFile.name)
+        File workingDirectory = extract(zipFile)
+        assert new File(workingDirectory, 'gradlew').canExecute()
+        assertSuccessfulExecution("${workingDirectory}/gradlew help", workingDirectory)
+    }
+
+    private void assertZipEntryDoesNotContainDocRef(File zipFile, String entry) {
+        File workingDirectory = extract(zipFile)
+        File file = new File(workingDirectory, entry)
+        assert !["// tag::", "// end::"].any { file.text.contains(it) }
+    }
+
+    private File extract(File zipFile) {
+        File workingDirectory = new File(temporaryFolder.root, zipFile.name)
         workingDirectory.mkdirs()
         assertSuccessfulExecution("unzip ${zipFile.getCanonicalPath()} -d ${workingDirectory.getCanonicalPath()}")
-
-        assert new File(workingDirectory, 'gradlew').canExecute()
-
-        assertSuccessfulExecution("${workingDirectory}/gradlew help", workingDirectory)
+        workingDirectory
     }
 
     private void assertSuccessfulExecution(String commandLine, File workingDirectory = null) {

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -1,5 +1,6 @@
 package org.gradle.docs.samples
 
+import org.gradle.docs.TestFile
 import spock.lang.Ignore
 import spock.lang.Unroll
 
@@ -94,6 +95,25 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
         buildAndFail("assembleDemoSample")
         then:
         result.task(":generateDemoPage").outcome == FAILED
+    }
+
+    def "can configure readme location"() {
+        makeSingleProject()
+        buildFile << """
+            ${sampleUnderTestDsl} {
+                readme = file('src/docs/samples/demo/CUSTOM_README.adoc')
+            }
+        """
+
+        TestFile directory = file('src/docs/samples/demo')
+        writeReadmeTo(directory, 'CUSTOM_README.adoc')
+        writeGroovyDslSampleTo(directory.file('groovy'))
+
+        when:
+        // If the readme doesn't exist for the sample, we fail to generate the sample page
+        ExecutionResult result = build("assembleDemoSample")
+        then:
+        result.task(":generateDemoPage").outcome == SUCCESS
     }
 
     // TODO: Generalize test

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -101,7 +101,7 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
         makeSingleProject()
         buildFile << """
             ${sampleUnderTestDsl} {
-                readme = file('src/docs/samples/demo/CUSTOM_README.adoc')
+                readmeFile = file('src/docs/samples/demo/CUSTOM_README.adoc')
             }
         """
 

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesTrait.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesTrait.groovy
@@ -33,8 +33,8 @@ trait SamplesTrait {
         return "documentation.samples.publishedSamples.${name}"
     }
 
-    static void writeReadmeTo(TestFile directory) {
-        directory.file('README.adoc') << '''
+    static void writeReadmeTo(TestFile directory, String file = 'README.adoc') {
+        directory.file(file) << '''
             |= Demo Sample
             |
             |Some doc

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
@@ -22,7 +22,7 @@ public interface Sample extends Named, SampleSummary {
      *
      * @return Property for configuring the readme file for the sample in Asciidoctor format.
      */
-    RegularFileProperty getReadme();
+    RegularFileProperty getReadmeFile();
 
     /**
      * @return Sample content that is shared by all DSLs.

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/Sample.java
@@ -4,6 +4,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 
 /**
  * Represent a sample to be documented. Each sample must contain at least a Groovy or Kotlin DSL sample.
@@ -17,9 +18,16 @@ public interface Sample extends Named, SampleSummary {
     DirectoryProperty getSampleDirectory();
 
     /**
+     * By Convention, this is README.adoc within the sample directory.
+     *
+     * @return Property for configuring the readme file for the sample in Asciidoctor format.
+     */
+    RegularFileProperty getReadme();
+
+    /**
      * @return Sample content that is shared by all DSLs.
      *
-     * By convention, this is the wrapper files, README and LICENSE.
+     * By convention, this is the wrapper files and LICENSE.
      */
     ConfigurableFileCollection getCommonContent();
 

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleArchiveBinary.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleArchiveBinary.java
@@ -1,6 +1,5 @@
 package org.gradle.docs.samples.internal;
 
-import org.gradle.api.Named;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -173,7 +173,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
         extension.getDistribution().getTestedInstalledSamples().from(extension.getTestedInstallRoot());
         extension.getDistribution().getTestedInstalledSamples().builtBy(extension.getDistribution().getInstalledSamples().builtBy((Callable<List<DirectoryProperty>>) () -> extension.getBinaries().withType(SampleExemplarBinary.class).stream().map(SampleExemplarBinary::getTestedInstallDirectory).collect(Collectors.toList())));
 
-        // Tempates
+        // Templates
         // TODO: The following is only in samples
         extension.getTemplatesRoot().convention(layout.getProjectDirectory().dir("src/docs/samples/templates"));
 

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -198,6 +198,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
     private void applyConventionsForSamples(SamplesInternal extension, SampleInternal sample) {
         String name = sample.getName();
         sample.getSampleDirectory().convention(extension.getSamplesRoot().dir(toKebabCase(name)));
+        sample.getReadme().convention(sample.getSampleDirectory().file("README.adoc"));
         sample.getDisplayName().convention(toTitleCase(name));
         sample.getDescription().convention("");
         sample.getCategory().convention("Uncategorized");
@@ -392,7 +393,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             contentBinary.getResourceSpec().convention(project.copySpec(spec -> spec.from(extension.getDistribution().getZippedSamples(), sub -> sub.into("zips"))));
             contentBinary.getSourcePattern().convention(contentBinary.getBaseName().map(baseName -> baseName + ".adoc"));
             contentBinary.getSampleInstallDirectory().convention(sample.getInstallDirectory());
-            contentBinary.getSourcePageFile().convention(sample.getSampleDirectory().file("README.adoc"));
+            contentBinary.getSourcePageFile().convention(sample.getReadme());
             contentBinary.getGradleVersion().convention(project.getGradle().getGradleVersion());
 
             // TODO: To make this lazy without afterEvaluate/eagerness, we need to be able to tell the tasks container that the samples container should be consulted

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -198,7 +198,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
     private void applyConventionsForSamples(SamplesInternal extension, SampleInternal sample) {
         String name = sample.getName();
         sample.getSampleDirectory().convention(extension.getSamplesRoot().dir(toKebabCase(name)));
-        sample.getReadme().convention(sample.getSampleDirectory().file("README.adoc"));
+        sample.getReadmeFile().convention(sample.getSampleDirectory().file("README.adoc"));
         sample.getDisplayName().convention(toTitleCase(name));
         sample.getDescription().convention("");
         sample.getCategory().convention("Uncategorized");
@@ -393,7 +393,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             contentBinary.getResourceSpec().convention(project.copySpec(spec -> spec.from(extension.getDistribution().getZippedSamples(), sub -> sub.into("zips"))));
             contentBinary.getSourcePattern().convention(contentBinary.getBaseName().map(baseName -> baseName + ".adoc"));
             contentBinary.getSampleInstallDirectory().convention(sample.getInstallDirectory());
-            contentBinary.getSourcePageFile().convention(sample.getReadme());
+            contentBinary.getSourcePageFile().convention(sample.getReadmeFile());
             contentBinary.getGradleVersion().convention(project.getGradle().getGradleVersion());
 
             // TODO: To make this lazy without afterEvaluate/eagerness, we need to be able to tell the tasks container that the samples container should be consulted

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/ZipSample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/ZipSample.java
@@ -5,19 +5,10 @@ import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UncheckedIOException;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.FileTree;
-import org.gradle.api.file.FileVisitDetails;
-import org.gradle.api.file.FileVisitor;
-import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.file.*;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.SkipWhenEmpty;
-import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -136,7 +127,7 @@ public abstract class ZipSample extends DefaultTask {
     }
 
     private byte[] readContent(FileVisitDetails fileDetails) throws IOException {
-        return com.google.common.io.Files.asByteSource(fileDetails.getFile()).read();
+        return Files.readAllBytes(fileDetails.getFile().toPath());
     }
 
     private boolean containsUserGuideRefs(String content) {

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/ZipSample.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/ZipSample.java
@@ -1,5 +1,8 @@
 package org.gradle.docs.samples.internal.tasks;
 
+import org.apache.tools.zip.UnixStat;
+import org.apache.tools.zip.ZipEntry;
+import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.ConfigurableFileCollection;
@@ -15,20 +18,22 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
-import org.apache.tools.zip.UnixStat;
-import org.apache.tools.zip.ZipEntry;
-import org.apache.tools.zip.ZipOutputStream;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Zips a sample to the given location.
- *
+ * <p>
  * Skips execution if there are no "main" content.  This is usually DSL-specific content.
+ * <p>
+ * Removes references to the documentation (e.g. the lines starting with {@code // tag::}) and {@code // end::})
  */
 public abstract class ZipSample extends DefaultTask {
     @InputFiles
@@ -92,10 +97,24 @@ public abstract class ZipSample extends DefaultTask {
                         } else {
                             entry = new ZipEntry(fileDetails.getRelativePath().getPathString());
                         }
+
                         entry.setSize(fileDetails.getSize());
                         entry.setUnixMode(UnixStat.FILE_FLAG | fileDetails.getMode());
                         zipStream.putNextEntry(entry);
-                        fileDetails.copyTo(zipStream);
+
+                        if (isTextFile(fileDetails)) {
+                            byte[] content = readContent(fileDetails);
+                            String contentString = new String(content, StandardCharsets.UTF_8);
+                            if (containsUserGuideRefs(contentString)) {
+                                zipStream.write(filterUserGuideRefs(contentString).getBytes());
+                            }
+                            else  {
+                                zipStream.write(content);
+                            }
+                        } else {
+                            fileDetails.copyTo(zipStream);
+                        }
+
                         zipStream.closeEntry();
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
@@ -105,6 +124,27 @@ public abstract class ZipSample extends DefaultTask {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private boolean isTextFile(FileVisitDetails fileDetails) throws IOException {
+        String fileName = fileDetails.getName();
+        if (Stream.of(".java", ".groovy", ".kt", ".kts", ".gradle", ".out", ".conf").anyMatch(s -> fileName.endsWith(s))) {
+            return true;
+        }
+        String type = Files.probeContentType(fileDetails.getFile().toPath());
+        return type != null && type.startsWith("text");
+    }
+
+    private byte[] readContent(FileVisitDetails fileDetails) throws IOException {
+        return com.google.common.io.Files.asByteSource(fileDetails.getFile()).read();
+    }
+
+    private boolean containsUserGuideRefs(String content) {
+        return content.contains("// tag::") || content.contains("// end::");
+    }
+
+    private String filterUserGuideRefs(String content) throws IOException {
+        return content.replaceAll("(// tag::|// end::).*\\R", "");
     }
 
     private FileTree getFilteredSourceTree() {


### PR DESCRIPTION
This way it's easier to read the sample sources.