### PR TITLE
Use `install: skip` instead of `install: true`

### DIFF
--- a/subprojects/executing-gradle-builds-on-travisci/contents/index.adoc
+++ b/subprojects/executing-gradle-builds-on-travisci/contents/index.adoc
@@ -78,7 +78,7 @@ The following configuration file tells Travis CI to build a Java project with JD
 [listing]
 ----
 language: java
-install: true
+install: skip
 
 os: linux
 dist: trusty

--- a/subprojects/guides-test-fixtures/.travis.yml
+++ b/subprojects/guides-test-fixtures/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-install: true
+install: skip
 
 os: linux
 dist: trusty


### PR DESCRIPTION
Using `install: true` does not skip `install` step but runs `true` command. To actually skip `install` step one should use `install: skip`. See https://docs.travis-ci.com/user/job-lifecycle/#skipping-the-installation-phase and https://github.com/travis-ci/docs-travis-ci-com/issues/2422#issuecomment-511170764