### PR TITLE
Skip validation tasks for non-promoted samples

### DIFF
--- a/subprojects/gradle-guides-plugin/README.adoc
+++ b/subprojects/gradle-guides-plugin/README.adoc
@@ -19,6 +19,10 @@ Each of the plugins generates a guide from Asciidoc source.
 
 == Changelog
 
+== 0.16.5
+
+- Skip asciidoctor-related validation tasks for non-promoted samples.
+
 == 0.16.4
 
 - Samples can be excluded from the samples index by setting the `sample` property to false.

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -341,8 +341,6 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
             |""".stripMargin()
     }
 
-    // TODO (donat) add test coverage for dsl-specific tests
-
     def "omits validation tasks for non-promoted samples"() {
         makeSingleProject()
         writeSampleUnderTest()

--- a/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
+++ b/subprojects/gradle-guides-plugin/src/functionalTest/groovy/org/gradle/docs/samples/SamplesPluginFunctionalTest.groovy
@@ -343,6 +343,25 @@ class SamplesPluginFunctionalTest extends AbstractSampleFunctionalSpec {
 
     // TODO (donat) add test coverage for dsl-specific tests
 
+    def "omits validation tasks for non-promoted samples"() {
+        makeSingleProject()
+        writeSampleUnderTest()
+        buildFile << """
+            documentation.samples.publishedSamples.demo {
+               promoted = false
+            }
+        """
+
+        when:
+        build('checkSamples')
+
+        then:
+        result.task(':docsTest').outcome == SUCCESS
+        result.task(':checkDemoSampleLinks') == null
+        result.task(':validateSampleDemoGroovy') == null
+        result.task(':validateSampleDemoKotlin') == null
+    }
+
     private void assertCanRunHelpTask(File zipFile) {
         def workingDirectory = new File(temporaryFolder.root, zipFile.name)
         workingDirectory.mkdirs()

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleArchiveBinary.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleArchiveBinary.java
@@ -62,4 +62,6 @@ public abstract class SampleArchiveBinary extends SampleBinary {
      * @return A installation directory containing this sample.  This can be used to get an installed version of the sample.
      */
     public abstract DirectoryProperty getInstallDirectory();
+
+    public abstract Property<Boolean> getPromoted();
 }

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleContentBinary.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SampleContentBinary.java
@@ -51,4 +51,6 @@ public abstract class SampleContentBinary extends SampleBinary implements Viewab
     public abstract RegularFileProperty getInstalledIndexPageFile();
 
     public abstract Property<String> getGradleVersion();
+
+    public abstract Property<Boolean> getPromoted();
 }


### PR DESCRIPTION
This PR removes the documentation validation steps for the non-promoted samples.

On the gradle/gradle build we soon will have a lot of unpromoted samples, which already exposed a few problems:
- the validation steps are really slow (~10 minutes) if we include the unpromoted samples
- some samples don't pass the validation as they don't define a build in the root directory (e.g. the snippet contains multiple builds).

To overcome that, this PR removes the problematic validation tasks for the non-promoted samples.

Right now the current goal is to unify the snippets/samples testing with the `docsTest` task. This remains intact with this PR. 

Thee PR is hacky as I was only able to modify the samples plugin's behavior with a bunch of `if` statements, although I haven't found a better way to model the validation skipping.