### PR TITLE
a "`" character seems to be missing

### DIFF
--- a/subprojects/building-java-libraries/contents/index.adoc
+++ b/subprojects/building-java-libraries/contents/index.adoc
@@ -149,7 +149,7 @@ The generated JUnit specification, `src/test/java/demo/LibraryTest.java` is show
 include::{samples-dir}/groovy-dsl-files/src/test/java/demo/LibraryTest.java[]
 ----
 
-The generated test class has a single https://junit.org/junit4/[JUnit 4] test. The test instantiates the `Library` class, invokes the `someLibraryMethod` method, and checks that the returned value is `true.
+The generated test class has a single https://junit.org/junit4/[JUnit 4] test. The test instantiates the `Library` class, invokes the `someLibraryMethod` method, and checks that the returned value is `true`.
 
 == Assemble the library JAR
 


### PR DESCRIPTION
a "`" character seems to be missing

The modification is related to [this web page](https://guides.gradle.org/building-java-libraries/)
![image](https://user-images.githubusercontent.com/3983683/83597705-8d285a00-a59a-11ea-8e61-2261599fbfe6.png)
![image](https://user-images.githubusercontent.com/3983683/83597814-be088f00-a59a-11ea-849f-ffd24ab4b943.png)

