### PR TITLE
Prepare a version which supports Gradle 7

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/gradle-guides-plugin/README.adoc
+++ b/subprojects/gradle-guides-plugin/README.adoc
@@ -19,6 +19,11 @@ Each of the plugins generates a guide from Asciidoc source.
 
 == Changelog
 
+== 0.16.9
+
+- Update to support Gradle 7
+- Fix resources being included several times
+
 == 0.16.6
 
 - Use Worker API for some sample related tasks so more things can run in parallel

--- a/subprojects/gradle-guides-plugin/build.gradle
+++ b/subprojects/gradle-guides-plugin/build.gradle
@@ -8,7 +8,13 @@ plugins {
 apply from: "$rootDir/gradle/functional-test.gradle"
 
 group = 'org.gradle.guides'
-version = '0.16.8'
+version = '0.16.9-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 repositories {
     jcenter()

--- a/subprojects/gradle-guides-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/subprojects/gradle-guides-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/internal/configure/AsciidoctorTasks.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/internal/configure/AsciidoctorTasks.java
@@ -5,15 +5,12 @@ import org.asciidoctor.gradle.AsciidoctorTask;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
-import org.gradle.api.logging.StandardOutputListener;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.docs.internal.RenderableContentBinary;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -26,7 +23,11 @@ public class AsciidoctorTasks {
         task.getInputs().files(binaries.stream().map(RenderableContentBinary::getResourceFiles).collect(Collectors.toList())).withPropertyName("resourceFiles").optional(true);
         task.resources(new Closure(IGNORED_CLOSURE_OWNER) {
             public Object doCall(Object ignore) {
-                binaries.stream().map(RenderableContentBinary::getResourceSpec).forEach(spec -> ((CopySpec)this.getDelegate()).with(spec.get()));
+                CopySpec copySpec = (CopySpec) this.getDelegate();
+                binaries.stream()
+                    .map(RenderableContentBinary::getResourceSpec)
+                    .distinct() // samples content all use the same resources by default, so if we don't filter there will be duplicates
+                    .forEach(spec -> copySpec.with(spec.get()));
                 return null;
             }
         });

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -89,19 +89,19 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
         // Samples binaries
         // TODO: This could be lazy if we had a way to make the TaskContainer require evaluation
         FileCollection generatedSanityCheckTest = createGeneratedTests(tasks, objects, layout);
-        extension.getBinaries().withType(SampleExemplarBinary.class).all(binary -> {
+        extension.getBinaries().withType(SampleExemplarBinary.class).configureEach(binary -> {
             if (!binary.getExplicitSanityCheck().get()) {
                 binary.getTestsContent().from(generatedSanityCheckTest);
             }
         });
 
-        extension.getBinaries().withType(SampleContentBinary.class).all(binary -> {
+        extension.getBinaries().withType(SampleContentBinary.class).configureEach(binary -> {
             createTasksForContentBinary(tasks, binary);
             createCheckTasksForContentBinary(tasks, binary, check);
             createTasksForSampleContentBinary(tasks, binary);
         });
-        extension.getBinaries().withType(SampleInstallBinary.class).all(binary -> createTasksForSampleInstallBinary(tasks, binary));
-        extension.getBinaries().withType(SampleArchiveBinary.class).all(binary -> createTasksForSampleArchiveBinary(tasks, layout, binary));
+        extension.getBinaries().withType(SampleInstallBinary.class).configureEach(binary -> createTasksForSampleInstallBinary(tasks, binary));
+        extension.getBinaries().withType(SampleArchiveBinary.class).configureEach(binary -> createTasksForSampleArchiveBinary(tasks, layout, binary));
 
         // Documentation for sample index
         registerGenerateSampleIndex(tasks, providers, objects, extension);
@@ -111,10 +111,10 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
 
         // Templates
         extension.getTemplates().configureEach(template -> applyConventionsForTemplates(extension, template));
-        extension.getTemplates().all(template -> createTasksForTemplates(layout, tasks, template));
+        extension.getTemplates().configureEach(template -> createTasksForTemplates(layout, tasks, template));
 
         // Testing (and binaries)
-        extension.getBinaries().withType(SampleExemplarBinary.class).all(binary -> createTasksForSampleExemplarBinary(tasks, binary));
+        extension.getBinaries().withType(SampleExemplarBinary.class).configureEach(binary -> createTasksForSampleExemplarBinary(tasks, binary));
         configureExemplarTestsForSamples(project, layout, tasks, extension, check);
         createCheckTaskForAsciidoctorContentBinary(project, "checkAsciidoctorSampleContents", extension.getBinaries().withType(TestableAsciidoctorSampleContentBinary.class), check, asciidoctorConfiguration);
 
@@ -257,7 +257,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             task.from(extension.getDistribution().getZippedSamples(), sub -> sub.into("zips"));
             task.from(extension.getDistribution().getInstalledSamples(), sub -> sub.into("samples"));
 
-            extension.getBinaries().withType(SampleContentBinary.class).all(binary -> {
+            extension.getBinaries().withType(SampleContentBinary.class).configureEach(binary -> {
                 // TODO: Minor difference with guide (copy the file) maybe we should have a file collection from the root
                 task.from(binary.getIndexPageFile());
             });

--- a/subprojects/guides-test-fixtures/build.gradle
+++ b/subprojects/guides-test-fixtures/build.gradle
@@ -7,18 +7,21 @@ apply from: "$rootDir/gradle/publishing.gradle"
 group = 'org.gradle.guides'
 version = '0.4'
 
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 repositories {
     jcenter()
 }
 
 dependencies {
-    compile gradleTestKit()
-    compile 'org.spockframework:spock-core:1.1-groovy-2.4', {
+    implementation gradleTestKit()
+    implementation 'org.spockframework:spock-core:1.1-groovy-2.4', {
         exclude module : 'groovy-all'
     }
-    testCompile localGroovy()
+    testImplementation localGroovy()
 }
 


### PR DESCRIPTION
This PR prepares a new release of the samples plugin.

- use toolchains to enforce use of Java 8 (previously it depended on
what was used to run the build, which I accidentally found out using
a composite)
- fix a bug which made it that all "samples binaries" used the same
resources directory so the same zips were added multiple times

I'm not sure why the fixtures were still using Java 7 and the `compile` configuration,
but in order to make it Gradle 7 compatible I moved everything to Java 8 + `implementation`.

/cc @wolfs 