### PR TITLE
Allow duplicate entries for zipped samples

### DIFF
--- a/subprojects/gradle-guides-plugin/README.adoc
+++ b/subprojects/gradle-guides-plugin/README.adoc
@@ -19,6 +19,10 @@ Each of the plugins generates a guide from Asciidoc source.
 
 == Changelog
 
+== 0.17.0
+
+- Allow duplicate entries for zipped samples
+
 == 0.16.9
 
 - Update to support Gradle 7

--- a/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/internal/configure/AsciidoctorTasks.java
+++ b/subprojects/gradle-guides-plugin/src/main/java/org/gradle/docs/internal/configure/AsciidoctorTasks.java
@@ -5,6 +5,7 @@ import org.asciidoctor.gradle.AsciidoctorTask;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.file.DuplicatesStrategy;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.docs.internal.RenderableContentBinary;
 
@@ -24,9 +25,9 @@ public class AsciidoctorTasks {
         task.resources(new Closure(IGNORED_CLOSURE_OWNER) {
             public Object doCall(Object ignore) {
                 CopySpec copySpec = (CopySpec) this.getDelegate();
+                copySpec.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
                 binaries.stream()
                     .map(RenderableContentBinary::getResourceSpec)
-                    .distinct() // samples content all use the same resources by default, so if we don't filter there will be duplicates
                     .forEach(spec -> copySpec.with(spec.get()));
                 return null;
             }


### PR DESCRIPTION
The previous version of the fix didn't work for some reason. It's
complicated to change how the binaries are wired with their conventions
to avoid duplication. Therefore, we just allow duplicates, which was
the previous (<Gradle 7) behavior in any case.