### PR TITLE
Update git-publish plugin

### DIFF
--- a/subprojects/guides-publication/build.gradle.kts
+++ b/subprojects/guides-publication/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.ajoberstar.git-publish") version("2.1.3")
+    id("org.ajoberstar.git-publish") version("4.2.0")
 }
 
 // When removing a guide that has been linked from elsewhere before, please add a redirect here


### PR DESCRIPTION
This one solves the issue caused by some libraries only being published to JCenter.
According to the [README](https://github.com/ajoberstar/gradle-git-publish), since 3.0.1, it uses Maven Central as a repository.

```
org.ajoberstar.git-publish:org.ajoberstar.git-publish.gradle.plugin:2.1.3 > org.ajoberstar:gradle-git-publish:2.1.3
```