### PR TITLE
Stop using Groovy XML lib to parse HTML

### DIFF
--- a/subprojects/gradle-guides-plugin/build.gradle.kts
+++ b/subprojects/gradle-guides-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 apply(from = "$projectDir/gradle/functional-test.gradle")
 
 group = "org.gradle.guides"
-version = "0.23.4"
+version = "0.24.0"
 
 java {
     toolchain {
@@ -30,10 +30,9 @@ repositories {
 }
 
 dependencies {
-    implementation("net.sourceforge.nekohtml:nekohtml:1.9.21")
-
     implementation("org.asciidoctor:asciidoctor-gradle-jvm:4.0.1")
     implementation("org.apache.ant:ant:1.9.16")
+    implementation("org.jsoup:jsoup:1.20.1")
 
     // For exemplar asciidoctor tests
     compileOnly("org.gradle:gradle-tooling-api:6.0.1")

--- a/subprojects/gradle-guides-plugin/src/test/groovy/org/gradle/docs/internal/CheckLinksSpec.groovy
+++ b/subprojects/gradle-guides-plugin/src/test/groovy/org/gradle/docs/internal/CheckLinksSpec.groovy
@@ -1,0 +1,89 @@
+package org.gradle.docs.internal
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CheckLinksSpec extends Specification {
+    @TempDir
+    Path tempDir
+
+    def "should extract absolute links from HTML"() {
+        given:
+        def html = """
+            <html>
+                <body>
+                    <a href="https://example.com">Example</a>
+                    <a href="https://gradle.org">Gradle</a>
+                </body>
+            </html>
+        """
+
+        when:
+        def anchors = CheckLinks.getAnchors(html)
+
+        then:
+        anchors.size() == 2
+        anchors.contains(new URI("https://example.com"))
+        anchors.contains(new URI("https://gradle.org"))
+    }
+
+    def "should extract relative links from HTML"() {
+        given:
+        def html = """
+            <html>
+                <body>
+                    <a href="/relative/path">Relative</a>
+                    <a href="another/path">Another</a>
+                </body>
+            </html>
+        """
+
+        when:
+        def anchors = CheckLinks.getAnchors(html)
+
+        then:
+        anchors.size() == 2
+        anchors.contains(new URI("/relative/path"))
+        anchors.contains(new URI("another/path"))
+    }
+
+    def "should handle empty document"() {
+        given:
+        def html = "<html><body></body></html>"
+
+        when:
+        def anchors = CheckLinks.getAnchors(html)
+
+        then:
+        anchors.isEmpty()
+    }
+
+    def "should handle malformed HTML"() {
+        given:
+        def html = """
+            <html>
+                <body>
+                    <a href="https://example.com">Example
+                    <a href="https://gradle.org">Gradle
+                </body>
+            </html>
+        """
+
+        when:
+        def anchors = CheckLinks.getAnchors(html)
+
+        then:
+        anchors.size() == 2
+        anchors.contains(new URI("https://example.com"))
+        anchors.contains(new URI("https://gradle.org"))
+    }
+
+    private File createHtmlFile(String content) {
+        def filePath = tempDir.resolve("test.html")
+        Files.writeString(filePath, content)
+        return filePath.toFile()
+    }
+} 


### PR DESCRIPTION
Fixes https://github.com/gradle/guides/issues/423

It's failing because it depends on out-of-date Groovy XML libs. This PR switches to `jsoup`.