### PR TITLE
Rename SyncWithProvider.getDestinationDirectory() to SyncWithProvider.getLazyDestinationDir()

### DIFF
--- a/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
+++ b/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/SamplesDocumentationPlugin.java
@@ -169,7 +169,7 @@ public class SamplesDocumentationPlugin implements Plugin<Project> {
             task.into(layout.getBuildDirectory().dir("tmp/" + task.getName()));
         });
 
-        template.getTemplateDirectory().convention(generateTemplate.flatMap(SyncWithProvider::getDestinationDirectory));
+        template.getTemplateDirectory().convention(generateTemplate.flatMap(SyncWithProvider::getLazyDestinationDir));
     }
 
     private void applyConventionsForTemplates(Samples extension, Template template) {

--- a/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/SyncWithProvider.java
+++ b/gradle-guides-plugin/src/main/java/org/gradle/docs/samples/internal/tasks/SyncWithProvider.java
@@ -15,7 +15,7 @@ import javax.inject.Inject;
 public abstract class SyncWithProvider extends Sync {
     @Inject
     public SyncWithProvider(ProjectLayout layout, ProviderFactory providers) {
-        getDestinationDirectory().set(layout.dir(providers.provider(this::getDestinationDir)));
+        getLazyDestinationDir().set(layout.dir(providers.provider(this::getDestinationDir)));
     }
 
     @Inject
@@ -27,5 +27,5 @@ public abstract class SyncWithProvider extends Sync {
     }
 
     @OutputDirectory
-    public abstract DirectoryProperty getDestinationDirectory();
+    public abstract DirectoryProperty getLazyDestinationDir();
 }


### PR DESCRIPTION
So we can add Sync.getDestinationDirectory() in Gradle core.