### PR TITLE
Remove unused GRADLE_CACHE_REMOTE_* credential env vars

### DIFF
--- a/.teamcity/src/main/kotlin/AbstractBuildType.kt
+++ b/.teamcity/src/main/kotlin/AbstractBuildType.kt
@@ -27,9 +27,6 @@ open class AbstractBuildType(init: BuildType.() -> Unit) : BuildType({
 
     params {
         param("env.LC_ALL", "en_US.UTF-8")
-        param("env.GRADLE_CACHE_REMOTE_URL", "%gradle.cache.remote.url%")
-        param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
-        param("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
         param("env.DEVELOCITY_ACCESS_KEY", "%ge.gradle.org.access.key%")
     }
 


### PR DESCRIPTION
Removes three TeamCity parameter mappings that nothing reads.

The remote build cache authenticates with `DEVELOCITY_ACCESS_KEY`, not HTTP basic auth, so these env vars are set on every build and consumed by nobody:

- `env.GRADLE_CACHE_REMOTE_URL`
- `env.GRADLE_CACHE_REMOTE_USERNAME`
- `env.GRADLE_CACHE_REMOTE_PASSWORD`

### How this was verified

The remote cache is configured by the conventions plugin. Decompiling the two versions in use across the org shows neither reads these:

- `gradle-enterprise-conventions-plugin` 0.10.3 — `BuildCacheConfigureAction` reads `DEVELOCITY_ACCESS_KEY`, `GRADLE_ENTERPRISE_ACCESS_KEY`, `gradle.cache.remote.server`, `gradle.cache.remote.push`, `cacheNode`, `disableLocalCache`
- `gradle-org-conventions-plugin` 0.15.0 — reads `DEVELOCITY_ACCESS_KEY`, `gradle.cache.remote.push`, `disableLocalCache`

Repos that configure the cache inline gate it on `DEVELOCITY_ACCESS_KEY` via `remote(develocity.buildCache)`.

An org-wide search for `GRADLE_CACHE_REMOTE_PASSWORD` / `GRADLE_CACHE_REMOTE_USERNAME` returns only TeamCity DSL writes plus one pass-through in `gradle/gradle-promote`. There are no readers anywhere.

Note that `gradle.cache.remote.server` **is** still read and is unaffected by this change.

### Context

SecOps flagged `gradle.cache.remote.password` for rotation. It is defined on the TeamCity `_Root` project, so all 44,667 build configs inherit it. The investigation found the credential is dead org-wide — 9 repos set these env vars, zero read them. It's basic-auth plumbing left over from the pre-Develocity HTTP build cache (the LastPass entry is still named for `eu.gradle.org`).

So rather than rotating it, we're removing the references and then deleting the parameters from `_Root`.

**These DSL removals must merge before the `_Root` parameters are deleted** — TeamCity treats an unresolved `%...%` reference as a hard error, so deleting the parameter first would break the build configurations that still reference it.
